### PR TITLE
Ensure no std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target/
+target/
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/porglezomp/bitmatch"
 documentation = "https://docs.rs/crate/bitmatch"
 readme = "README.md"
 keywords = ["bitpacking", "binary", "decoder", "matching", "macro"]
-categories = ["parsing"]
+categories = ["parsing", "no-std"]
 
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs.rs Documentation Version Number](https://docs.rs/bitmatch/badge.svg)](https://docs.rs/crate/)
 
 The bitmatch crate provides tools for packing and unpacking integers as
-sequences of bits.
+sequences of bits. Supports `#![no_std]`.
 
 ## Examples
 

--- a/ensure-no-std/.cargo/config
+++ b/ensure-no-std/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/ensure-no-std/Cargo.toml
+++ b/ensure-no-std/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ensure-no-std"
+version = "0.1.0"
+authors = ["Cassie Jones <code@witchoflight.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitmatch = { path = ".." }
+

--- a/ensure-no-std/src/lib.rs
+++ b/ensure-no-std/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+use bitmatch::bitmatch;
+
+#[bitmatch]
+pub fn bitrev(x: u8) -> u8 {
+    #[bitmatch]
+    let "abcdefgh" = x;
+    bitpack!("hgfedcba")
+}
+
+#[bitmatch]
+pub fn decode(x: u8) -> u8 {
+    #[bitmatch]
+    match x {
+        "00xy_aaaa" if x == y => a,
+        "00??_aaaa" => !a,
+        "0100_aabb" => a + b,
+        "0101_aabb" => a - b,
+        "0110_aabb" => a * b,
+        "0111_aabb" => a / b,
+        "1000_aabb" => (a < b) as u8,
+        "10??_aabb" => (a == b) as u8,
+        "11??_aaaa" => 255 - a,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 //! both must be used inside a function that has the `#[bitmatch]` attribute
 //! on it.
 //!
+//! Since it generates normal bitmasking, it can be used in `#![no_std]`
+//! crates.
+//!
 //! # Examples
 //!
 //! Using `#[bitmatch]` with a `let` unpacks the bits into separate

--- a/test.py
+++ b/test.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from contextlib import contextmanager
+import subprocess
+import os
+
+
+@contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)
+
+
+print("Checking no-std compatibility...")
+with cd('ensure-no-std'):
+    subprocess.check_call(['cargo', 'build'])


### PR DESCRIPTION
Add a test to check that the crate is `#![no_std]` compatible and add a mention to the documentation.

@jamesmunns does this look good?

Fixes #1 